### PR TITLE
feat: implement `panel.set_can_become_main_window(bool)`

### DIFF
--- a/src/raw_nspanel.rs
+++ b/src/raw_nspanel.rs
@@ -49,14 +49,26 @@ impl RawNSPanel {
         unsafe {
             cls.add_ivar::<BOOL>("can_become_key_window");
 
+            cls.add_ivar::<BOOL>("can_become_main_window");
+
             cls.add_method(
                 sel!(setCanBecomeKeyWindow:),
                 Self::handle_set_can_become_key_window as extern "C" fn(&mut Object, Sel, BOOL),
             );
 
             cls.add_method(
+                sel!(setCanBecomeMainWindow:),
+                Self::handle_set_can_become_main_window as extern "C" fn(&mut Object, Sel, BOOL),
+            );
+
+            cls.add_method(
                 sel!(canBecomeKeyWindow),
                 Self::can_become_key_window as extern "C" fn(&Object, Sel) -> BOOL,
+            );
+
+            cls.add_method(
+                sel!(canBecomeMainWindow),
+                Self::can_become_main_window as extern "C" fn(&Object, Sel) -> BOOL,
             );
 
             cls.add_method(
@@ -72,6 +84,10 @@ impl RawNSPanel {
         unsafe { *this.get_ivar::<BOOL>("can_become_key_window") }
     }
 
+    extern "C" fn can_become_main_window(this: &Object, _: Sel) -> BOOL {
+        unsafe { *this.get_ivar::<BOOL>("can_become_main_window") }
+    }
+
     extern "C" fn dealloc(this: &mut Object, _cmd: Sel) {
         unsafe {
             let superclass = class!(NSObject);
@@ -83,6 +99,10 @@ impl RawNSPanel {
 
     extern "C" fn handle_set_can_become_key_window(this: &mut Object, _: Sel, value: BOOL) {
         unsafe { this.set_ivar::<BOOL>("can_become_key_window", value) };
+    }
+
+    extern "C" fn handle_set_can_become_main_window(this: &mut Object, _: Sel, value: BOOL) {
+        unsafe { this.set_ivar::<BOOL>("can_become_main_window", value) };
     }
 
     pub fn show(&self) {
@@ -156,6 +176,10 @@ impl RawNSPanel {
         let _: () = unsafe { msg_send![self, setCanBecomeKeyWindow: value] };
     }
 
+    pub fn set_can_become_main_window(&self, value: bool) {
+        let _: () = unsafe { msg_send![self, setCanBecomeMainWindow: value] };
+    }
+
     pub fn released_when_closed(&self, value: bool) {
         let _: () = unsafe { msg_send![self, setReleasedWhenClosed: value] };
     }
@@ -201,6 +225,9 @@ impl RawNSPanel {
 
             // By the default, the panel can become the key window
             panel.set_can_become_key_window(true);
+
+            // By the default, the panel can't become at the main window
+            panel.set_can_become_main_window(false);
 
             // Add a tracking area to the panel's content view,
             // so that we can receive mouse events such as mouseEntered and mouseExited


### PR DESCRIPTION
This pull request introduces several changes to the `RawNSPanel` implementation in the `src/raw_nspanel.rs` file. The main focus is on adding support for the `can_become_main_window` property and its associated methods.

Key changes include:

### Adding `can_become_main_window` Property:

* Added the `can_become_main_window` instance variable to the `RawNSPanel` class.

### Adding Methods for `can_become_main_window`:

* Implemented the `setCanBecomeMainWindow:` method to set the `can_become_main_window` property.
* Implemented the `canBecomeMainWindow` method to get the `can_become_main_window` property.
* Added the `handle_set_can_become_main_window` function to handle setting the `can_become_main_window` property.
* Added the `can_become_main_window` function to retrieve the value of the `can_become_main_window` property.
* Added the `set_can_become_main_window` method to set the `can_become_main_window` property in the `RawNSPanel` instance.

### Default Behavior:

* Set the default behavior of the panel to not become the main window by default.