### PR TITLE
feat: add more class methods

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tauri-nspanel"
-version = "2.0.0"
+version = "2.0.1"
 authors = ["Victor Aremu <me@victorare.mu>"]
 description = "A plugin for subclassing Tauri's NSWindow to NSPanel"
 edition = "2021"

--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ To ensure that your NSPanel is fully released:
 ```rust
 // ...
 
-panel.released_when_closed(true);
+panel.set_released_when_closed(true);
 panel.close();
 ```
 

--- a/examples/fullscreen/src-tauri/Cargo.lock
+++ b/examples/fullscreen/src-tauri/Cargo.lock
@@ -3269,7 +3269,7 @@ dependencies = [
 
 [[package]]
 name = "tauri-nspanel"
-version = "2.0.0"
+version = "2.0.1"
 dependencies = [
  "bitflags 2.6.0",
  "block",

--- a/examples/fullscreen/src-tauri/src/main.rs
+++ b/examples/fullscreen/src-tauri/src/main.rs
@@ -4,7 +4,9 @@
 )]
 
 use tauri::{AppHandle, Manager, WebviewWindow};
-use tauri_nspanel::{panel_delegate, ManagerExt, WebviewWindowExt, cocoa::appkit::NSWindowCollectionBehavior};
+use tauri_nspanel::{
+  cocoa::appkit::NSWindowCollectionBehavior, panel_delegate, ManagerExt, WebviewWindowExt,
+};
 
 fn main() {
   tauri::Builder::default()
@@ -66,8 +68,8 @@ fn init(app_handle: &AppHandle) {
   // - display on the same space as the full screen window
   // - join all spaces
   panel.set_collection_behaviour(
-    NSWindowCollectionBehavior::NSWindowCollectionBehaviorFullScreenAuxiliary |
-    NSWindowCollectionBehavior::NSWindowCollectionBehaviorCanJoinAllSpaces
+    NSWindowCollectionBehavior::NSWindowCollectionBehaviorFullScreenAuxiliary
+      | NSWindowCollectionBehavior::NSWindowCollectionBehaviorCanJoinAllSpaces,
   );
 
   panel.set_delegate(delegate);
@@ -91,7 +93,7 @@ fn hide_panel(handle: AppHandle) {
 fn close_panel(handle: AppHandle) {
   let panel = handle.get_webview_panel("main").unwrap();
 
-  panel.released_when_closed(true);
+  panel.set_released_when_closed(true);
 
   panel.close();
 }

--- a/examples/vanilla/src-tauri/src/main.rs
+++ b/examples/vanilla/src-tauri/src/main.rs
@@ -70,7 +70,7 @@ fn hide_panel(handle: AppHandle) {
 fn close_panel(handle: AppHandle) {
   let panel = handle.get_webview_panel("main").unwrap();
 
-  panel.released_when_closed(true);
+  panel.set_released_when_closed(true);
 
   panel.close();
 }

--- a/src/raw_nspanel.rs
+++ b/src/raw_nspanel.rs
@@ -116,6 +116,11 @@ impl RawNSPanel {
         flag == YES
     }
 
+    pub fn is_floating_panel(&self) -> bool {
+        let flag: BOOL = unsafe { msg_send![self, isFloatingPanel] };
+        flag == YES
+    }
+
     pub fn make_key_window(&self) {
         let _: () = unsafe { msg_send![self, makeKeyWindow] };
     }
@@ -180,8 +185,52 @@ impl RawNSPanel {
         let _: () = unsafe { msg_send![self, setCanBecomeMainWindow: value] };
     }
 
-    pub fn released_when_closed(&self, value: bool) {
+    pub fn set_floating_panel(&self, value: bool) {
+        let _: () = unsafe { msg_send![self, setFloatingPanel: value] };
+    }
+
+    pub fn set_accepts_mouse_moved_events(&self, value: bool) {
+        let _: () = unsafe { msg_send![self, setAcceptsMouseMovedEvents: value] };
+    }
+
+    pub fn set_ignore_mouse_events(&self, value: bool) {
+        let _: () = unsafe { msg_send![self, setIgnoresMouseEvents: value] };
+    }
+
+    pub fn set_hides_on_deactivate(&self, value: bool) {
+        let _: () = unsafe { msg_send![self, setHidesOnDeactivate: value] };
+    }
+
+    pub fn set_moveable_by_window_background(&self, value: bool) {
+        let _: () = unsafe { msg_send![self, setMovableByWindowBackground: value] };
+    }
+
+    pub fn set_becomes_key_only_if_needed(&self, value: bool) {
+        let _: () = unsafe { msg_send![self, setBecomesKeyOnlyIfNeeded: value] };
+    }
+
+    pub fn set_works_when_modal(&self, value: bool) {
+        let _: () = unsafe { msg_send![self, setWorksWhenModal: value] };
+    }
+
+    pub fn set_opaque(&self, value: bool) {
+        let _: () = unsafe { msg_send![self, setOpaque: value] };
+    }
+
+    pub fn set_has_shadow(&self, value: bool) {
+        let _: () = unsafe { msg_send![self, setHasShadow: value] };
+    }
+
+    pub fn set_released_when_closed(&self, value: bool) {
         let _: () = unsafe { msg_send![self, setReleasedWhenClosed: value] };
+    }
+
+    #[deprecated(
+        since = "2.0.1",
+        note = "Use set_released_when_closed(bool) instead. This method will be removed in a future version."
+    )]
+    pub fn released_when_closed(&self, value: bool) {
+        self.set_released_when_closed(value);
     }
 
     pub fn close(&self) {


### PR DESCRIPTION
This pull request includes several changes to the `tauri-nspanel` project, including version updates, method renaming, and new functionality in the `RawNSPanel` implementation. The most important changes are summarized below:

Version Update:
* [`Cargo.toml`](diffhunk://#diff-2e9d962a08321605940b5a657135052fbcef87b5e360662bb527c96d9a615542L3-R3): Updated the version from `2.0.0` to `2.0.1`.

Method Renaming:
* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L92-R92): Updated the method `released_when_closed` to `set_released_when_closed` in the example code.
* [`examples/fullscreen/src-tauri/src/main.rs`](diffhunk://#diff-d3dc6fa4c6cd25c1d8120f1f472a4ee44d9301a7faea48b4c5ccca63cfafab90L94-R96): Renamed `released_when_closed` to `set_released_when_closed` in multiple functions.
* [`examples/vanilla/src-tauri/src/main.rs`](diffhunk://#diff-07aba1df28891af8108090f8fb0b27dd253b2601454d76e14c00e15307f0e879L73-R73): Renamed `released_when_closed` to `set_released_when_closed` in the `close_panel` function.

New Functionality:
* [`src/raw_nspanel.rs`](diffhunk://#diff-f6fe90ce12a36dda59e92df413a62f701bc836edf66bd93dc591ff28af53b8caR119-R123): Added several new methods to the `RawNSPanel` implementation, including `set_floating_panel`, `set_accepts_mouse_moved_events`, `set_ignore_mouse_events`, `set_hides_on_deactivate`, `set_moveable_by_window_background`, `set_becomes_key_only_if_needed`, `set_works_when_modal`, `set_opaque`, `set_has_shadow`, and `is_floating_panel`. Also marked `released_when_closed` as deprecated. [[1]](diffhunk://#diff-f6fe90ce12a36dda59e92df413a62f701bc836edf66bd93dc591ff28af53b8caR119-R123) [[2]](diffhunk://#diff-f6fe90ce12a36dda59e92df413a62f701bc836edf66bd93dc591ff28af53b8caL183-R235)

Code Formatting:
* [`examples/fullscreen/src-tauri/src/main.rs`](diffhunk://#diff-d3dc6fa4c6cd25c1d8120f1f472a4ee44d9301a7faea48b4c5ccca63cfafab90L7-R9): Reformatted import statements for better readability.
* [`examples/fullscreen/src-tauri/src/main.rs`](diffhunk://#diff-d3dc6fa4c6cd25c1d8120f1f472a4ee44d9301a7faea48b4c5ccca63cfafab90L69-R72): Adjusted the formatting of the `set_collection_behaviour` method call.