### PR TITLE
feat: add more panel methods

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tauri-nspanel"
-version = "0.0.0"
+version = "0.0.1"
 authors = ["Victor Aremu"]
 description = "A plugin for subclassing Tauri's NSWindow to NSPanel"
 edition = "2021"

--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ To ensure that your NSPanel is fully released:
 ```rust
 // ...
 
-panel.released_when_closed(true);
+panel.set_released_when_closed(true);
 panel.close();
 ```
 6. See the [examples](/examples) to learn how to use `tauri-nspanel`. For more information on panel methods, please refer to the [documentation page](https://ahkohd.github.io/tauri-nspanel/tauri_nspanel/raw_nspanel/struct.RawNSPanel.html).

--- a/examples/fullscreen/src-tauri/Cargo.lock
+++ b/examples/fullscreen/src-tauri/Cargo.lock
@@ -2980,7 +2980,7 @@ dependencies = [
 
 [[package]]
 name = "tauri-nspanel"
-version = "0.0.0"
+version = "0.0.1"
 dependencies = [
  "bitflags 2.6.0",
  "block",

--- a/examples/fullscreen/src-tauri/src/main.rs
+++ b/examples/fullscreen/src-tauri/src/main.rs
@@ -85,6 +85,6 @@ fn hide_panel(handle: AppHandle<Wry>) {
 #[tauri::command]
 fn close_panel(handle: AppHandle<Wry>) {
     let panel = handle.get_panel("main").unwrap();
-    panel.released_when_closed(true);
+    panel.set_released_when_closed(true);
     panel.close();
 }

--- a/examples/vanilla/src-tauri/Cargo.lock
+++ b/examples/vanilla/src-tauri/Cargo.lock
@@ -2980,7 +2980,7 @@ dependencies = [
 
 [[package]]
 name = "tauri-nspanel"
-version = "0.0.0"
+version = "0.0.1"
 dependencies = [
  "bitflags 2.6.0",
  "block",

--- a/examples/vanilla/src-tauri/src/main.rs
+++ b/examples/vanilla/src-tauri/src/main.rs
@@ -63,6 +63,6 @@ fn hide_panel(handle: AppHandle<Wry>) {
 #[tauri::command]
 fn close_panel(handle: AppHandle<Wry>) {
     let panel = handle.get_panel("main").unwrap();
-    panel.released_when_closed(true);
+    panel.set_released_when_closed(true);
     panel.close();
 }

--- a/src/raw_nspanel.rs
+++ b/src/raw_nspanel.rs
@@ -1,7 +1,7 @@
 use bitflags::bitflags;
 use cocoa::{
     appkit::{NSView, NSViewHeightSizable, NSViewWidthSizable, NSWindowCollectionBehavior},
-    base::{id, nil, BOOL, NO, YES},
+    base::{id, nil, BOOL, YES},
     foundation::NSRect,
 };
 use objc::{
@@ -42,28 +42,33 @@ impl INSObject for RawNSPanel {
 }
 
 impl RawNSPanel {
-    /// Returns YES to ensure that RawNSPanel can become a key window
-    extern "C" fn can_become_key_window(_: &Object, _: Sel) -> BOOL {
-        YES
-    }
-
-    extern "C" fn dealloc(this: &mut Object, _cmd: Sel) {
-        unsafe {
-            let superclass = class!(NSObject);
-            let dealloc: extern "C" fn(&mut Object, Sel) =
-                msg_send![super(this, superclass), dealloc];
-            dealloc(this, _cmd);
-        }
-    }
-
     fn define_class() -> &'static Class {
         let mut cls = ClassDecl::new(CLS_NAME, class!(NSPanel))
             .unwrap_or_else(|| panic!("Unable to register {} class", CLS_NAME));
 
         unsafe {
+            cls.add_ivar::<BOOL>("can_become_key_window");
+
+            cls.add_ivar::<BOOL>("can_become_main_window");
+
+            cls.add_method(
+                sel!(setCanBecomeKeyWindow:),
+                Self::handle_set_can_become_key_window as extern "C" fn(&mut Object, Sel, BOOL),
+            );
+
+            cls.add_method(
+                sel!(setCanBecomeMainWindow:),
+                Self::handle_set_can_become_main_window as extern "C" fn(&mut Object, Sel, BOOL),
+            );
+
             cls.add_method(
                 sel!(canBecomeKeyWindow),
                 Self::can_become_key_window as extern "C" fn(&Object, Sel) -> BOOL,
+            );
+
+            cls.add_method(
+                sel!(canBecomeMainWindow),
+                Self::can_become_main_window as extern "C" fn(&Object, Sel) -> BOOL,
             );
 
             cls.add_method(
@@ -75,6 +80,35 @@ impl RawNSPanel {
         cls.register()
     }
 
+    extern "C" fn handle_set_can_become_key_window(this: &mut Object, _: Sel, value: BOOL) {
+        unsafe {
+            this.set_ivar::<BOOL>("can_become_key_window", value);
+        }
+    }
+
+    extern "C" fn handle_set_can_become_main_window(this: &mut Object, _: Sel, value: BOOL) {
+        unsafe {
+            this.set_ivar::<BOOL>("can_become_main_window", value);
+        }
+    }
+
+    extern "C" fn can_become_key_window(this: &Object, _: Sel) -> BOOL {
+        unsafe { *this.get_ivar::<BOOL>("can_become_key_window") }
+    }
+
+    extern "C" fn can_become_main_window(this: &Object, _: Sel) -> BOOL {
+        unsafe { *this.get_ivar::<BOOL>("can_become_main_window") }
+    }
+
+    extern "C" fn dealloc(this: &mut Object, _cmd: Sel) {
+        unsafe {
+            let superclass = class!(NSObject);
+            let dealloc: extern "C" fn(&mut Object, Sel) =
+                msg_send![super(this, superclass), dealloc];
+            dealloc(this, _cmd);
+        }
+    }
+
     pub fn show(&self) {
         self.make_first_responder(Some(self.content_view()));
         self.order_front_regardless();
@@ -83,6 +117,11 @@ impl RawNSPanel {
 
     pub fn is_visible(&self) -> bool {
         let flag: BOOL = unsafe { msg_send![self, isVisible] };
+        flag == YES
+    }
+
+    pub fn is_floating_panel(&self) -> bool {
+        let flag: BOOL = unsafe { msg_send![self, isFloatingPanel] };
         flag == YES
     }
 
@@ -142,8 +181,60 @@ impl RawNSPanel {
         let _: () = unsafe { msg_send![self, setDelegate: delegate] };
     }
 
-    pub fn released_when_closed(&self, flag: bool) {
-        let _: () = unsafe { msg_send![self, setReleasedWhenClosed: if flag {YES} else {NO}] };
+    pub fn set_can_become_key_window(&self, value: bool) {
+        let _: () = unsafe { msg_send![self, setCanBecomeKeyWindow: value] };
+    }
+
+    pub fn set_can_become_main_window(&self, value: bool) {
+        let _: () = unsafe { msg_send![self, setCanBecomeMainWindow: value] };
+    }
+
+    pub fn set_floating_panel(&self, value: bool) {
+        let _: () = unsafe { msg_send![self, setFloatingPanel: value] };
+    }
+
+    pub fn set_accepts_mouse_moved_events(&self, value: bool) {
+        let _: () = unsafe { msg_send![self, setAcceptsMouseMovedEvents: value] };
+    }
+
+    pub fn set_ignore_mouse_events(&self, value: bool) {
+        let _: () = unsafe { msg_send![self, setIgnoresMouseEvents: value] };
+    }
+
+    pub fn set_hides_on_deactivate(&self, value: bool) {
+        let _: () = unsafe { msg_send![self, setHidesOnDeactivate: value] };
+    }
+
+    pub fn set_moveable_by_window_background(&self, value: bool) {
+        let _: () = unsafe { msg_send![self, setMovableByWindowBackground: value] };
+    }
+
+    pub fn set_becomes_key_only_if_needed(&self, value: bool) {
+        let _: () = unsafe { msg_send![self, setBecomesKeyOnlyIfNeeded: value] };
+    }
+
+    pub fn set_works_when_modal(&self, value: bool) {
+        let _: () = unsafe { msg_send![self, setWorksWhenModal: value] };
+    }
+
+    pub fn set_opaque(&self, value: bool) {
+        let _: () = unsafe { msg_send![self, setOpaque: value] };
+    }
+
+    pub fn set_has_shadow(&self, value: bool) {
+        let _: () = unsafe { msg_send![self, setHasShadow: value] };
+    }
+
+    pub fn set_released_when_closed(&self, value: bool) {
+        let _: () = unsafe { msg_send![self, setReleasedWhenClosed: value] };
+    }
+
+    #[deprecated(
+        since = "0.0.1",
+        note = "Use set_released_when_closed(bool) instead. This method will be removed in a future version."
+    )]
+    pub fn released_when_closed(&self, value: bool) {
+        self.set_released_when_closed(value);
     }
 
     pub fn close(&self) {
@@ -179,9 +270,17 @@ impl RawNSPanel {
     pub fn from_window<R: Runtime>(window: Window<R>) -> Id<Self> {
         let nswindow: id = window.ns_window().unwrap() as _;
         let nspanel_class: id = unsafe { msg_send![Self::class(), class] };
+
         unsafe {
             object_setClass(nswindow, nspanel_class);
+
             let panel = Id::from_retained_ptr(nswindow as *mut RawNSPanel);
+
+            // By default, allow the panel to become the key window
+            panel.set_can_become_key_window(true);
+
+            // By default, a panel cannot become the main window
+            panel.set_can_become_main_window(false);
 
             // Add a tracking area to the panel's content view,
             // so that we can receive mouse events such as mouseEntered and mouseExited


### PR DESCRIPTION
This pull request includes several changes to the `tauri-nspanel` project, focusing on updating the version, modifying method names, and adding new functionalities to the `RawNSPanel` class.

Version update:
* Updated the version in `Cargo.toml` from `0.0.0` to `0.0.1`.

Method name changes:
* Changed method name `released_when_closed` to `set_released_when_closed` in `README.md` and example files. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L92-R92) [[2]](diffhunk://#diff-d3dc6fa4c6cd25c1d8120f1f472a4ee44d9301a7faea48b4c5ccca63cfafab90L88-R88) [[3]](diffhunk://#diff-07aba1df28891af8108090f8fb0b27dd253b2601454d76e14c00e15307f0e879L66-R66)

Enhancements to `RawNSPanel` class:
* Removed unnecessary imports and added new instance variables and methods (`setCanBecomeKeyWindow`, `setCanBecomeMainWindow`, etc.) to `RawNSPanel`. [[1]](diffhunk://#diff-f6fe90ce12a36dda59e92df413a62f701bc836edf66bd93dc591ff28af53b8caL4-R4) [[2]](diffhunk://#diff-f6fe90ce12a36dda59e92df413a62f701bc836edf66bd93dc591ff28af53b8caL45-R73) [[3]](diffhunk://#diff-f6fe90ce12a36dda59e92df413a62f701bc836edf66bd93dc591ff28af53b8caR83-R111) [[4]](diffhunk://#diff-f6fe90ce12a36dda59e92df413a62f701bc836edf66bd93dc591ff28af53b8caR123-R127) [[5]](diffhunk://#diff-f6fe90ce12a36dda59e92df413a62f701bc836edf66bd93dc591ff28af53b8caL145-R237) [[6]](diffhunk://#diff-f6fe90ce12a36dda59e92df413a62f701bc836edf66bd93dc591ff28af53b8caR273-R284)
* Deprecated the `released_when_closed` method in favor of `set_released_when_closed`.refactor: deprecate `panel.relase_when_close()`