### PR TITLE
feat(panel): implement auto-activation on mouse hover

### DIFF
--- a/examples/fullscreen/public/index.html
+++ b/examples/fullscreen/public/index.html
@@ -25,6 +25,11 @@
       margin: 5px;
       cursor: default;
       user-select: none;
+      transition: background-color 0.3s ease;
+    }
+
+    .DragArea:hover {
+      background-color: #d1d1d1;
     }
   </style>
 </head>

--- a/examples/fullscreen/src-tauri/src/main.rs
+++ b/examples/fullscreen/src-tauri/src/main.rs
@@ -32,6 +32,7 @@ fn init(app_handle: &AppHandle) {
   let window: WebviewWindow = app_handle.get_webview_window("main").unwrap();
 
   let panel = window.to_panel().unwrap();
+  panel.activate();
 
   let delegate = panel_delegate!(MyPanelDelegate {
     window_did_become_key,

--- a/src/raw_nspanel.rs
+++ b/src/raw_nspanel.rs
@@ -1,9 +1,10 @@
 use bitflags::bitflags;
 use cocoa::{
     appkit::{NSView, NSViewHeightSizable, NSViewWidthSizable, NSWindowCollectionBehavior},
-    base::{id, nil, BOOL, YES},
+    base::{id, nil, BOOL, YES, NO},
     foundation::NSRect,
 };
+
 use objc::{
     class,
     declare::ClassDecl,
@@ -26,6 +27,12 @@ bitflags! {
 
 extern "C" {
     pub fn object_setClass(obj: id, cls: id) -> id;
+    
+    // Mouse tracking related selectors
+    pub fn NSMouseEntered(event: id);
+    pub fn NSMouseExited(event: id);
+    pub fn NSMouseMoved(event: id);
+    pub fn NSCursorUpdate(event: id);
 }
 
 const CLS_NAME: &str = "RawNSPanel";
@@ -47,12 +54,38 @@ impl RawNSPanel {
         YES
     }
 
+    // Add this new method to prevent automatic resignation
+    extern "C" fn can_resign_key_window(_: &Object, _: Sel) -> BOOL {
+        // Return NO to prevent the panel from automatically resigning key window status
+        unsafe { NO }  // Import NO alongside YES at the top of the file
+    }
+
     extern "C" fn dealloc(this: &mut Object, _cmd: Sel) {
         unsafe {
             let superclass = class!(NSObject);
             let dealloc: extern "C" fn(&mut Object, Sel) =
                 msg_send![super(this, superclass), dealloc];
             dealloc(this, _cmd);
+        }
+    }
+
+    extern "C" fn mouse_entered(_this: &Object, _sel: Sel, _event: id) {
+        unsafe {
+            println!("Mouse entered panel");  // Add debugging message
+            let this: id = _this as *const _ as id;
+            
+            // Force the panel to become key and active
+            let _: () = msg_send![this, makeKeyWindow];
+            
+            // Add explicit type annotation for the content view
+            let content_view: id = msg_send![this, contentView];
+            let _: () = msg_send![this, makeFirstResponder: content_view];
+        }
+    }
+
+    extern "C" fn mouse_exited(_this: &Object, _sel: Sel, _event: id) {
+        unsafe {
+            println!("Mouse exited panel");  // Add debugging message
         }
     }
 
@@ -66,9 +99,26 @@ impl RawNSPanel {
                 Self::can_become_key_window as extern "C" fn(&Object, Sel) -> BOOL,
             );
 
+            // Add this new method to prevent the panel from resigning key window status
+            cls.add_method(
+                sel!(canResignKeyWindow),
+                Self::can_resign_key_window as extern "C" fn(&Object, Sel) -> BOOL,
+            );
+
             cls.add_method(
                 sel!(dealloc),
                 Self::dealloc as extern "C" fn(&mut Object, Sel),
+            );
+            
+            // Add mouse tracking methods
+            cls.add_method(
+                sel!(mouseEntered:),
+                Self::mouse_entered as extern "C" fn(&Object, Sel, id),
+            );
+            
+            cls.add_method(
+                sel!(mouseExited:),
+                Self::mouse_exited as extern "C" fn(&Object, Sel, id),
             );
         }
 
@@ -163,6 +213,23 @@ impl RawNSPanel {
         let _: () = unsafe { msg_send![self, setHidesOnDeactivate: value] };
     }
 
+    pub fn activate(&self) {
+        // Configure panel for interaction
+        self.set_accepts_mouse_moved_events(true);
+        self.set_becomes_key_only_if_needed(false);
+        self.set_works_when_modal(true);
+        self.set_hides_on_deactivate(false);
+        
+        // Make the window visible and activated with higher window level
+        self.set_level(3); // NSFloatingWindowLevel
+        self.order_front_regardless();
+        self.make_key_and_order_front(None);
+        self.make_key_window();
+        
+        // Set first responder to ensure focus
+        self.make_first_responder(Some(self.content_view()));
+    }
+
     pub fn set_moveable_by_window_background(&self, value: bool) {
         let _: () = unsafe { msg_send![self, setMovableByWindowBackground: value] };
     }
@@ -209,16 +276,17 @@ impl RawNSPanel {
         let track_view: id = unsafe { msg_send![class!(NSTrackingArea), alloc] };
         let track_view: id = unsafe {
             msg_send![
-            track_view,
-            initWithRect: bounds
-            options: NSTrackingAreaOptions::NSTrackingActiveAlways
-            | NSTrackingAreaOptions::NSTrackingMouseEnteredAndExited
-            | NSTrackingAreaOptions::NSTrackingMouseMoved
-            | NSTrackingAreaOptions::NSTrackingCursorUpdate
-            owner: view
-            userInfo: nil
+                track_view,
+                initWithRect: bounds
+                options: NSTrackingAreaOptions::NSTrackingActiveAlways.bits()
+                | NSTrackingAreaOptions::NSTrackingMouseEnteredAndExited.bits()
+                | NSTrackingAreaOptions::NSTrackingMouseMoved.bits()
+                | NSTrackingAreaOptions::NSTrackingCursorUpdate.bits()
+                owner: self
+                userInfo: nil
             ]
         };
+        
         let autoresizing_mask = NSViewWidthSizable | NSViewHeightSizable;
         let () = unsafe { msg_send![view, setAutoresizingMask: autoresizing_mask] };
         let () = unsafe { msg_send![view, addTrackingArea: track_view] };
@@ -232,10 +300,19 @@ impl RawNSPanel {
             object_setClass(nswindow, nspanel_class);
             let panel = Id::from_retained_ptr(nswindow as *mut RawNSPanel);
 
-            // Add a tracking area to the panel's content view,
-            // so that we can receive mouse events such as mouseEntered and mouseExited
+            // Add a tracking area to the panel's content view
             panel.add_tracking_area();
-
+            
+            // Configure panel to maintain focus - do this immediately
+            panel.set_accepts_mouse_moved_events(true);
+            panel.set_becomes_key_only_if_needed(false);
+            panel.set_hides_on_deactivate(false);
+            panel.set_works_when_modal(true);
+            
+            // Set to floating window level for better focus retention
+            panel.set_level(3); // NSFloatingWindowLevel = 3
+            panel.make_key_window(); // Make it the key window initially
+            
             panel
         }
     }


### PR DESCRIPTION
- Add tracking area to automatically activate panel when mouse enters
- Override canResignKeyWindow to prevent focus loss
- Configure NSPanel with optimal window level and focus settings
- Ensure panel maintains interactive state without requiring clicks