### PR TITLE
Fix segmentation fault error in add_event_listener in tauri v2.8

### DIFF
--- a/src/panel.rs
+++ b/src/panel.rs
@@ -505,7 +505,7 @@ macro_rules! panel {
 
                     unsafe {
                         // Use object_setClass from the runtime
-                        extern "C" {
+                        unsafe extern "C" {
                             fn object_setClass(
                                 obj: *mut $crate::objc2_foundation::NSObject,
                                 cls: *const $crate::objc2::runtime::AnyClass,
@@ -528,6 +528,9 @@ macro_rules! panel {
                                 "Failed to retain panel",
                             ))
                         })?;
+
+                        // Initialize the ivars properly after class change
+                        (*panel).ivars().event_handler.set(std::ptr::null());
 
                         // Add tracking area if configured
                         $($(


### PR DESCRIPTION
When I deleted `Cargo.lock` in the `examples/basic`, `examples/panel_builder`, and `examples/mouse_tracking` (assuming the behaviour is the same for every other example), running the apps with `cargo run` result in `segmentation fault`.

Here's my tauri info on `examples/basic` for reference: (I ran rustup update before contributing)
```
❯ bun run tauri info

[✔] Environment
    - OS: Mac OS 15.5.0 arm64 (X64)
    ✔ Xcode Command Line Tools: installed
    ✔ rustc: 1.88.0 (6b00bc388 2025-06-23) (Homebrew)
    ✔ cargo: 1.88.0 (Homebrew)
    ✔ rustup: 1.28.2 (e4f3ad6f8 2025-04-28)
    ✔ Rust toolchain: stable-aarch64-apple-darwin (default)
    - node: 20.19.2
    - pnpm: 8.15.4
    - npm: 10.8.2
    - bun: 1.2.18
    - deno: deno 2.4.3

[-] Packages
    - tauri 🦀: 2.8.1
    - tauri-build 🦀: 2.4.0
    - wry 🦀: 0.53.1
    - tao 🦀: 0.34.2
    - @tauri-apps/api : not installed!
    - @tauri-apps/cli : 2.8.0

[-] Plugins

[-] App
    - build-type: bundle
    - CSP: default-src blob: data: filesystem: ws: wss: http: https: tauri: 'unsafe-eval' 'unsafe-inline' 'self' img-src: 'self'; connect-src ipc: http://ipc.localhost
    - frontendDist: ../public
```

Basically, while tracing with `println`'s everywhere, I found that in `panel.rs`, in the panel macro, the `set_event_handler` fn was causing the seg fault.

In here:
```rs
let old_ptr = ivars.event_handler.get();
if !old_ptr.is_null() {
    let _: () = $crate::objc2::msg_send![old_ptr as *const $crate::objc2_foundation::NSObject, release];
}
```
The `old_ptr` returned `0x1`, which meant that the ivars weren't properly initialized.

So my PR fixes this by initializing the ivars properly after class change